### PR TITLE
Fix for a minor but annoying unicode error

### DIFF
--- a/behave/runner.py
+++ b/behave/runner.py
@@ -785,7 +785,7 @@ class Runner(object):
         else:
             for step in current_job.steps:
                 if step.status == 'skipped':
-                    writebuf.write("Skipped step because of previous error"
+                    writebuf.write(u"Skipped step because of previous error"
                                    " - Scenario:{0}|step:{1}\n"
                                    .format(current_job.name, step.name))
 


### PR DESCRIPTION
To find this bug I managed to behave-parallel to run without having parallel_element variable in the Configuration object set. The error I got was the misleading

UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 17: ordinal not in range(128)

instead of the helpful

ValueError: execute_steps() called outside of feature

So here is my fix. Such as it is.
